### PR TITLE
Make analyzer connect and read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,14 @@ Temporary Items
 
 build/
 rethinkdb_data
+
+# VSCode directories
+.vscode/*
+# !.vscode/settings.json
+# !.vscode/tasks.json
+# !.vscode/launch.json
+# !.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,19 @@ rethinkdb_data
 
 # Local History for Visual Studio Code
 .history/
+
+# Python ignores
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+Pipfile.lock
+Pipfile

--- a/crypto-analyzer/Dockerfile
+++ b/crypto-analyzer/Dockerfile
@@ -1,3 +1,6 @@
 FROM quoinedev/python3.6-pandas-alpine
-COPY src/main.py app.py
-ENTRYPOINT ["python", "./app.py"]
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+COPY src/ myapp/
+WORKDIR /myapp/
+ENTRYPOINT ["python", "./main.py"]

--- a/crypto-analyzer/requirements.txt
+++ b/crypto-analyzer/requirements.txt
@@ -2,6 +2,7 @@
 certifi==2020.4.5.1
 chardet==3.0.4
 idna==2.9
+pyyaml==5.3.1
 requests==2.23.0
 rethinkdb==2.4.6
 six==1.14.0

--- a/crypto-analyzer/requirements.txt
+++ b/crypto-analyzer/requirements.txt
@@ -1,3 +1,8 @@
-altgraph==0.17
-macholib==1.14
-PyInstaller==3.6
+-i https://pypi.org/simple
+certifi==2020.4.5.1
+chardet==3.0.4
+idna==2.9
+requests==2.23.0
+rethinkdb==2.4.6
+six==1.14.0
+urllib3==1.25.9

--- a/crypto-analyzer/src/main.py
+++ b/crypto-analyzer/src/main.py
@@ -1,7 +1,11 @@
+from utils.adapter_request_helper import subscribe_products
+
 def main():
     print("==================================")
     print("HELLO!! -- CRYPTO-ANALYZER SERVICE")
     print("==================================")
+
+    subscribe_products(["BTC-EUR"])
 
 
 if __name__ == "__main__":

--- a/crypto-analyzer/src/main.py
+++ b/crypto-analyzer/src/main.py
@@ -1,4 +1,5 @@
 from utils.adapter_request_helper import subscribe_products
+from utils.db_connection import connect_to_db, print_feed
 
 def main():
     print("==================================")
@@ -6,6 +7,9 @@ def main():
     print("==================================")
 
     subscribe_products(["BTC-EUR"])
+
+    connect_to_db()
+    print_feed()
 
 
 if __name__ == "__main__":

--- a/crypto-analyzer/src/main.py
+++ b/crypto-analyzer/src/main.py
@@ -1,14 +1,22 @@
+import time
 from utils.adapter_request_helper import subscribe_products
 from utils.db_connection import connect_to_db, print_feed
+from utils.config_handling import ConfigHandler
+
 
 def main():
     print("==================================")
     print("HELLO!! -- CRYPTO-ANALYZER SERVICE")
     print("==================================")
 
-    subscribe_products(["BTC-EUR"])
+    print("Reading config file...")
+    handler = ConfigHandler()
 
-    connect_to_db()
+    print("Sleeping for ten seconds...")
+    time.sleep(10)
+    subscribe_products(handler, "BTC-EUR")
+
+    connect_to_db(handler)
     print_feed()
 
 

--- a/crypto-analyzer/src/resources/analyzer_configuration.yml
+++ b/crypto-analyzer/src/resources/analyzer_configuration.yml
@@ -11,3 +11,4 @@ coinbase_adapter:
 rethinkdb:
     host: rethinkdb
     port: 28015
+    db_name: cryptobot

--- a/crypto-analyzer/src/resources/analyzer_configuration.yml
+++ b/crypto-analyzer/src/resources/analyzer_configuration.yml
@@ -1,0 +1,8 @@
+coinbase_adapter:
+    subscribe_products_endpoint: /api/market/subscribe
+    host: coinbase_adapter
+    port: 9000
+
+rethinkdb:
+    host: rethinkdb
+    port: 28015

--- a/crypto-analyzer/src/resources/analyzer_configuration.yml
+++ b/crypto-analyzer/src/resources/analyzer_configuration.yml
@@ -2,6 +2,11 @@ coinbase_adapter:
     subscribe_products_endpoint: /api/market/subscribe
     host: coinbase_adapter
     port: 9000
+    post_request_body_template:
+        type: Subscribe
+        productIds: []
+        channels:
+            - ticker
 
 rethinkdb:
     host: rethinkdb

--- a/crypto-analyzer/src/utils/adapter_request_helper.py
+++ b/crypto-analyzer/src/utils/adapter_request_helper.py
@@ -1,0 +1,25 @@
+import requests
+HOST = "http://coinbase_adapter:9000"
+subscribe_endpoint = HOST + "/api/market/subscribe"
+
+def subscribe_product(product):
+    body = {"type": "Subscribe",
+            "productIds": [
+                product 
+            ],
+            "channels": [
+                "ticker"
+            ]}
+
+    r = requests.post(subscribe_endpoint, json=body)
+    print(r.text)
+
+def subscribe_products(product_ids):
+    body = {"type": "Subscribe",
+            "productIds": product_ids,
+            "channels": [
+                "ticker"
+            ]}
+
+    r = requests.post(subscribe_endpoint, json=body)
+    print(r.text)

--- a/crypto-analyzer/src/utils/adapter_request_helper.py
+++ b/crypto-analyzer/src/utils/adapter_request_helper.py
@@ -1,12 +1,12 @@
 import requests
 
 
-def subscribe_product(handler, *args):
+def subscribe_products(config_handler, *args):
     if not all(map(lambda product_id: isinstance(product_id, str), args)):
         raise ValueError
-    
-    subscribe_endpoint = handler.products_subscription_endpoint
-    body = handler.post_request_body_template
+
+    subscribe_endpoint = config_handler.products_subscription_endpoint
+    body = config_handler.post_request_body_template
 
     body['productIds'] = list(args)
     

--- a/crypto-analyzer/src/utils/adapter_request_helper.py
+++ b/crypto-analyzer/src/utils/adapter_request_helper.py
@@ -1,25 +1,14 @@
 import requests
-HOST = "http://coinbase_adapter:9000"
-subscribe_endpoint = HOST + "/api/market/subscribe"
 
-def subscribe_product(product):
-    body = {"type": "Subscribe",
-            "productIds": [
-                product 
-            ],
-            "channels": [
-                "ticker"
-            ]}
 
-    r = requests.post(subscribe_endpoint, json=body)
-    print(r.text)
+def subscribe_product(handler, *args):
+    if not all(map(lambda product_id: isinstance(product_id, str), args)):
+        raise ValueError
+    
+    subscribe_endpoint = handler.products_subscription_endpoint
+    body = handler.post_request_body_template
 
-def subscribe_products(product_ids):
-    body = {"type": "Subscribe",
-            "productIds": product_ids,
-            "channels": [
-                "ticker"
-            ]}
-
+    body['productIds'] = list(args)
+    
     r = requests.post(subscribe_endpoint, json=body)
     print(r.text)

--- a/crypto-analyzer/src/utils/config_handling.py
+++ b/crypto-analyzer/src/utils/config_handling.py
@@ -9,3 +9,26 @@ class ConfigHandler:
                 self.config_data = yaml.load(config_file, Loader=yaml.Loader)
         except OSError as err:
             print(err)
+
+    @property
+    def products_subscription_endpoint(self):
+        if not self.config_data:
+            raise ValueError
+
+        return 'http://{host}:{port}{endpoint}'.format(
+            host = self.config_data['coinbase_adapter']['host'],
+            port = self.config_data['coinbase_adapter']['port'],
+            endpoint = self.config_data['coinbase_adapter']['subscribe_products_endpoint']
+        )
+
+    @property
+    def rethink_host(self):
+        return self.config_data['rethinkdb']['host']
+
+    @property
+    def rethink_port(self):
+        return self.config_data['rethinkdb']['port']
+
+    @property
+    def post_request_body_template(self):
+        return self.config_data['coinbase_adapter']['post_request_body_template']

--- a/crypto-analyzer/src/utils/config_handling.py
+++ b/crypto-analyzer/src/utils/config_handling.py
@@ -32,3 +32,7 @@ class ConfigHandler:
     @property
     def post_request_body_template(self):
         return self.config_data['coinbase_adapter']['post_request_body_template']
+
+    @property
+    def rethink_db_name(self):
+        return self.config_data['rethinkdb']['db_name']

--- a/crypto-analyzer/src/utils/config_handling.py
+++ b/crypto-analyzer/src/utils/config_handling.py
@@ -1,0 +1,11 @@
+import yaml
+
+class ConfigHandler:
+    config_data = None
+
+    def __init__(self):
+        try:
+            with open("../resources/analayzer_configuration.yml", "r") as config_file:
+                self.config_data = yaml.load(config_file)
+        except OSError as err:
+            print(err)

--- a/crypto-analyzer/src/utils/config_handling.py
+++ b/crypto-analyzer/src/utils/config_handling.py
@@ -5,7 +5,7 @@ class ConfigHandler:
 
     def __init__(self):
         try:
-            with open("../resources/analayzer_configuration.yml", "r") as config_file:
-                self.config_data = yaml.load(config_file)
+            with open("./resources/analyzer_configuration.yml", "r") as config_file:
+                self.config_data = yaml.load(config_file, Loader=yaml.Loader)
         except OSError as err:
             print(err)

--- a/crypto-analyzer/src/utils/db_connection.py
+++ b/crypto-analyzer/src/utils/db_connection.py
@@ -1,0 +1,8 @@
+from rethinkdb import r
+
+def connect_to_db():
+    r.connect(host='rethinkdb', db='cryptobot').repl()
+
+def print_feed():
+    for change in r.table('messages').changes().run():
+        print(change['new_val'])

--- a/crypto-analyzer/src/utils/db_connection.py
+++ b/crypto-analyzer/src/utils/db_connection.py
@@ -1,8 +1,14 @@
+import sys
 from rethinkdb import r
 
-def connect_to_db():
-    r.connect(host='rethinkdb', db='cryptobot').repl()
+def connect_to_db(config_handler):
+    r.connect(
+        host=config_handler.rethink_host,
+        port=config_handler.rethink_port,
+        db=config_handler.rethink_db_name
+    ).repl()
 
 def print_feed():
     for change in r.table('messages').changes().run():
         print(change['new_val'])
+        sys.stdout.flush()


### PR DESCRIPTION
# Initial implementation of crypto-analyzer-service

The main points of this current implementation are as follow:

- Implementation of sending a _POST_ request to the `coinbase-adapter-service` which initiates the subscription of a specific product to coinbase's websocket and starts populating **rethinkdb**
- Implementation of connecting and reading new changes made to the `cryptobot` database and in particular new _inserts_ at the `messages` table
- Printing output to console