### PR TITLE
Validates subscription to wsfeed

### DIFF
--- a/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/CoinbaseAdapterJson.kt
+++ b/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/CoinbaseAdapterJson.kt
@@ -25,4 +25,8 @@ object CoinbaseAdapterJson: ConfigurableJackson(KotlinModule()
 
 fun AutoMappingConfiguration<ObjectMapper>.withCryptobotMappings() = apply {
     text(BiDiMapping(::Channel, Channel::value))
+    text(BiDiMapping(::coinbaseMessageTypeAsIn, ::coinbaseMessageTypeAsOut))
 }
+
+private fun coinbaseMessageTypeAsIn(s: String) = CoinbaseMessageType.betterValueOf(s)
+private fun coinbaseMessageTypeAsOut(enum: CoinbaseMessageType) = enum.name.toLowerCase()

--- a/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/CoinbaseAdapterRepository.kt
+++ b/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/CoinbaseAdapterRepository.kt
@@ -53,19 +53,19 @@ class CoinbaseAdapterRepoImpl(realTimeDb: RealTimeDb): CoinbaseAdapterRepository
         hashMapOf(
             "type" to type.name,
             "sequence" to sequence.value,
-            "product_id" to product_id.value,
+            "product_id" to productId.value,
             "price" to price.value,
-            "open_24h" to open_24h.value,
-            "volume_24h" to volume_24h.value,
-            "low_24h" to low_24h.value,
-            "high_24h" to high_24h.value,
-            "volume_30d" to volume_30d.value,
-            "best_bid" to best_bid.value,
-            "best_ask" to best_ask.value,
+            "open_24h" to open24h.value,
+            "volume_24h" to volume24h.value,
+            "low_24h" to low24h.value,
+            "high_24h" to high24h.value,
+            "volume_30d" to volume30d.value,
+            "best_bid" to bestBid.value,
+            "best_ask" to bestAsk.value,
             "side" to side.name,
             "time" to time.toOffsetDateTimeUTC(),
-            "trade_id" to trade_id.value,
-            "last_size" to last_size.value
+            "trade_id" to tradeId.value,
+            "last_size" to lastSize.value
         )
 }
 

--- a/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/coinbase/CoinbaseJson.kt
+++ b/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/coinbase/CoinbaseJson.kt
@@ -6,8 +6,8 @@ import org.http4k.lens.BiDiMapping
 import java.time.Instant
 
 fun AutoMappingConfiguration<ObjectMapper>.withCoinbaseMappings() = apply {
-    text(BiDiMapping(::toTypeEnum, Type::name))
-    text(BiDiMapping(::toSideEnum, Side::name))
+    text(BiDiMapping(::typeAsIn, ::typeAsOut))
+    text(BiDiMapping(::sideAsIn, ::sideAsOut))
     long(BiDiMapping(::CoinSequence, CoinSequence::value))
     long(BiDiMapping(::TradeId, TradeId::value))
     text(BiDiMapping(::ProductId, ProductId::value))
@@ -23,5 +23,7 @@ fun AutoMappingConfiguration<ObjectMapper>.withCoinbaseMappings() = apply {
     BiDiMapping(Instant::parse, Instant::toString)
 }
 
-private fun toTypeEnum(s: String) = enumValueOf<Type>(s.toUpperCase())
-private fun toSideEnum(s: String) = enumValueOf<Side>(s.toUpperCase())
+private fun typeAsIn(s: String) = Type.betterValueOf(s)
+private fun typeAsOut(enum: Type) = enum.name.toLowerCase()
+private fun sideAsIn(s: String) = Side.betterValueOf(s)
+private fun sideAsOut(enum: Side) = enum.name.toLowerCase()

--- a/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/coinbase/domain.kt
+++ b/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/coinbase/domain.kt
@@ -1,8 +1,21 @@
 package me.pysquad.cryptobot.coinbase
 
 
-enum class Type { TICKER }
-enum class Side { BUY, SELL }
+enum class Type {
+    TICKER;
+
+    companion object {
+        fun betterValueOf(s: String) = valueOf(s.toUpperCase())
+    }
+}
+enum class Side {
+    BUY,
+    SELL;
+
+    companion object {
+        fun betterValueOf(s: String) = valueOf(s.toUpperCase())
+    }
+}
 
 data class CoinSequence(val value: Long)
 data class ProductId(val value: String)

--- a/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/coinbase/messages.kt
+++ b/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/coinbase/messages.kt
@@ -1,36 +1,79 @@
 package me.pysquad.cryptobot.coinbase
 
-import me.pysquad.cryptobot.CoinbaseAdapterJson.auto
+import org.http4k.core.Body
+import org.http4k.core.HttpMessage
+import org.http4k.format.Jackson.json
 import org.http4k.websocket.WsMessage
 import java.time.Instant
 
 data class CoinbaseProductMessage(
-    val type: Type,
-    val sequence: CoinSequence,
-    val product_id: ProductId,
-    val price: Price,
-    val open_24h: Open24h,
-    val volume_24h: Volume24h,
-    val low_24h: Low24h,
-    val high_24h: High24h,
-    val volume_30d: Volume30d,
-    val best_bid: BestBid,
-    val best_ask: BestAsk,
-    val side: Side,
-    val time: Instant,
-    val trade_id: TradeId,
-    val last_size: LastSize
+        val type: Type,
+        val sequence: CoinSequence,
+        val productId: ProductId,
+        val price: Price,
+        val open24h: Open24h,
+        val volume24h: Volume24h,
+        val low24h: Low24h,
+        val high24h: High24h,
+        val volume30d: Volume30d,
+        val bestBid: BestBid,
+        val bestAsk: BestAsk,
+        val side: Side,
+        val time: Instant,
+        val tradeId: TradeId,
+        val lastSize: LastSize
 ) {
     companion object {
-        val wsLens = WsMessage.auto<CoinbaseProductMessage>().toLens()
+        fun fromWsMessage(wsMessage: WsMessage): CoinbaseProductMessage {
+            val wsJsonLens = WsMessage.json().toLens()
+
+            return with(wsJsonLens(wsMessage)) {
+                CoinbaseProductMessage(
+                        Type.betterValueOf(get("type").asText()),
+                        CoinSequence(get("sequence").asLong()),
+                        ProductId(get("product_id").asText()),
+                        Price(get("price").asText()),
+                        Open24h(get("open_24h").asText()),
+                        Volume24h(get("volume_24h").asText()),
+                        Low24h(get("low_24h").asText()),
+                        High24h(get("high_24h").asText()),
+                        Volume30d(get("volume_30d").asText()),
+                        BestBid(get("best_bid").asText()),
+                        BestAsk(get("best_ask").asText()),
+                        Side.betterValueOf(get("side").asText()),
+                        Instant.parse(get("time").asText() as CharSequence),
+                        TradeId(get("trade_id").asLong()),
+                        LastSize(get("last_size").asText())
+                )
+            }
+        }
     }
 }
 
-data class GetSandboxCoinbaseMessage(
+data class GetSandboxCoinbaseProfileMessage(
         val id: String,
         val userId: String,
         val name: String,
         val active: Boolean,
         val isDefault: Boolean,
         val createdAt: String
-)
+) {
+    companion object {
+        fun toListOfMessages(httpMessage: HttpMessage): List<GetSandboxCoinbaseProfileMessage> {
+            val httpJsonLens = Body.json().toLens()
+
+            return with(httpJsonLens(httpMessage)) {
+                map {
+                    GetSandboxCoinbaseProfileMessage(
+                        it["id"].asText(),
+                        it["user_id"].asText(),
+                        it["name"].asText(),
+                        it["active"].asBoolean(),
+                        it["is_default"].asBoolean(),
+                        it["created_at"].asText()
+                    )
+                }
+            }
+        }
+    }
+}

--- a/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/domain.kt
+++ b/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/domain.kt
@@ -1,5 +1,14 @@
 package me.pysquad.cryptobot
 
-enum class CoinbaseMessageType { Subscribe, Unsubscribe, Subscriptions }
+enum class CoinbaseMessageType {
+    SUBSCRIBE,
+    UNSUBSCRIBE,
+    SUBSCRIPTIONS,
+    ERROR;
+
+    companion object {
+        fun betterValueOf(s: String) = valueOf(s.toUpperCase())
+    }
+}
 data class Channel(val value: String)
 data class CoinbaseSandboxApiCredentials(val key: String, val secret: String, val passphrase: String)

--- a/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/endpoints/SubscribeToMarket.kt
+++ b/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/endpoints/SubscribeToMarket.kt
@@ -1,11 +1,16 @@
 package me.pysquad.cryptobot.endpoints
 
 import me.pysquad.cryptobot.Channel
-import me.pysquad.cryptobot.CoinbaseMessageType.Subscribe
+import me.pysquad.cryptobot.CoinbaseMessageType.ERROR
+import me.pysquad.cryptobot.CoinbaseMessageType.SUBSCRIBE
+import me.pysquad.cryptobot.CoinbaseMessageType.SUBSCRIPTIONS
+import me.pysquad.cryptobot.CoinbaseSubscribeRequest
 import me.pysquad.cryptobot.coinbase.CoinbaseApi
+import me.pysquad.cryptobot.coinbase.CoinbaseWsFeedError
+import me.pysquad.cryptobot.coinbase.CoinbaseWsFeedResponse
+import me.pysquad.cryptobot.coinbase.CoinbaseWsFeedSuccess
 import me.pysquad.cryptobot.coinbase.ProductId
 import me.pysquad.cryptobot.common.Endpoint
-import me.pysquad.cryptobot.CoinbaseSubscribeRequest
 import me.pysquad.cryptobot.security.SecurityProvider
 import org.http4k.contract.meta
 import org.http4k.core.HttpHandler
@@ -13,27 +18,46 @@ import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
+import org.http4k.core.with
 
 class SubscribeToMarket(private val coinbase: CoinbaseApi): Endpoint {
     private val exampleSubscribeRequest =
             CoinbaseSubscribeRequest(
-                    type = Subscribe,
+                    type = SUBSCRIBE,
                     productIds = listOf(ProductId("ETH-GBP")),
                     channels = listOf(Channel("ticker"))
             )
 
+    private val exampleSuccessCoinbaseWsFeedResponse =
+            CoinbaseWsFeedSuccess(
+                    type = SUBSCRIPTIONS,
+                    message = "Success",
+                    productIds = listOf("BTC-EUR")
+            )
+
+    private val exampleErrorCoinbaseWsFeedResponse =
+            CoinbaseWsFeedError(
+                    type = ERROR,
+                    message = "Failed to subscribe",
+                    reason = "BTasdC-EUR is not a valid product"
+            )
+
     override val contractRoute =
-        "/coinbase/subscribe" meta {
+        "/coinbase/wsFeed/subscribe" meta {
             summary = "Subscribes to the real-time market data flow on orders and trades."
             receiving(CoinbaseSubscribeRequest.lens to exampleSubscribeRequest)
-            returning(OK)
+            returning(OK, CoinbaseWsFeedResponse.successLens to exampleSuccessCoinbaseWsFeedResponse)
+            returning(OK, CoinbaseWsFeedResponse.errorLens to exampleErrorCoinbaseWsFeedResponse)
             security = SecurityProvider.basicAuth()
         } bindContract POST to handler()
 
     private fun handler(): HttpHandler = { req: Request ->
         with(CoinbaseSubscribeRequest.lens(req)) {
-            coinbase.subscribe(this)
-            Response(OK).body("Connecting to coinbase websocket...\n")
+            when(val resp = coinbase.subscribe(this)) {
+                is CoinbaseWsFeedSuccess -> Response(OK).with(CoinbaseWsFeedResponse.successLens of resp)
+                is CoinbaseWsFeedError -> Response(OK).with(CoinbaseWsFeedResponse.errorLens of resp)
+                else -> Response(OK)
+            }
         }
     }
 }

--- a/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/messages.kt
+++ b/coinbase-adapter/src/main/kotlin/me/pysquad/cryptobot/messages.kt
@@ -1,7 +1,7 @@
 package me.pysquad.cryptobot
 
 import me.pysquad.cryptobot.CoinbaseAdapterJson.auto
-import me.pysquad.cryptobot.coinbase.GetSandboxCoinbaseMessage
+import me.pysquad.cryptobot.coinbase.GetSandboxCoinbaseProfileMessage
 import me.pysquad.cryptobot.coinbase.ProductId
 import org.http4k.core.Body
 import org.http4k.core.Credentials
@@ -14,6 +14,16 @@ data class CoinbaseSubscribeRequest(
 ) {
     companion object {
         val lens = Body.auto<CoinbaseSubscribeRequest>().toLens()
+    }
+
+    fun toNativeCoinbaseRequest(): String = CoinbaseAdapterJson {
+        val productIdsJson = productIds.map { string(it.value) }
+        val channelsJson = channels.map { string(it.value) }
+        obj(
+                "type" to type.name.toLowerCase().asJsonValue(),
+                "product_ids" to array(productIdsJson),
+                "channels" to array(channelsJson)
+        ).toPrettyString()
     }
 }
 
@@ -44,7 +54,7 @@ data class SandboxCoinbaseProfile(
     companion object {
         val listLens = Body.auto<List<SandboxCoinbaseProfile>>().toLens()
 
-        fun of(message: GetSandboxCoinbaseMessage): SandboxCoinbaseProfile =
+        fun of(message: GetSandboxCoinbaseProfileMessage): SandboxCoinbaseProfile =
             SandboxCoinbaseProfile(
                     message.id,
                     message.userId,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,14 +23,14 @@ services:
     restart: always
     ports:
     - 9000:9000
-  crypto-analyzer-service:
-    build: ./crypto-analyzer
-    depends_on:
-      - realtime-db
-    container_name: crypto_analyzer
-    restart: always
-    environment:
-      RETHINK_DB_HOST: ${RETHINK_DB_HOST}
-      COINBASE_ADAPTER_BASIC_AUTH_USER: ${COINBASE_ADAPTER_BASIC_AUTH_USER}
-      COINBASE_ADAPTER_BASIC_AUTH_PWD: ${COINBASE_ADAPTER_BASIC_AUTH_PWD}
-      CB_HOST: ${CB_HOST}
+#  crypto-analyzer-service:
+#    build: ./crypto-analyzer
+#    depends_on:
+#      - realtime-db
+#    container_name: crypto_analyzer
+#    restart: always
+#    environment:
+#      RETHINK_DB_HOST: ${RETHINK_DB_HOST}
+#      COINBASE_ADAPTER_BASIC_AUTH_USER: ${COINBASE_ADAPTER_BASIC_AUTH_USER}
+#      COINBASE_ADAPTER_BASIC_AUTH_PWD: ${COINBASE_ADAPTER_BASIC_AUTH_PWD}
+#      CB_HOST: ${CB_HOST}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,14 +23,14 @@ services:
     restart: always
     ports:
     - 9000:9000
-#  crypto-analyzer-service:
-#    build: ./crypto-analyzer
-#    depends_on:
-#      - realtime-db
-#    container_name: crypto_analyzer
-#    restart: always
-#    environment:
-#      RETHINK_DB_HOST: ${RETHINK_DB_HOST}
-#      COINBASE_ADAPTER_BASIC_AUTH_USER: ${COINBASE_ADAPTER_BASIC_AUTH_USER}
-#      COINBASE_ADAPTER_BASIC_AUTH_PWD: ${COINBASE_ADAPTER_BASIC_AUTH_PWD}
-#      CB_HOST: ${CB_HOST}
+  crypto-analyzer-service:
+    build: ./crypto-analyzer
+    depends_on:
+      - realtime-db
+    container_name: crypto_analyzer
+    restart: always
+    environment:
+      RETHINK_DB_HOST: ${RETHINK_DB_HOST}
+      COINBASE_ADAPTER_BASIC_AUTH_USER: ${COINBASE_ADAPTER_BASIC_AUTH_USER}
+      COINBASE_ADAPTER_BASIC_AUTH_PWD: ${COINBASE_ADAPTER_BASIC_AUTH_PWD}
+      CB_HOST: ${CB_HOST}


### PR DESCRIPTION
### Changes
- The endpoint to subscribe to ws feed has been updated to 
`POST /api/coinbase/wsFeed/subscribe`. In body where we pass in information
about what kind of subscription it will be, the value of the json field `type` can be
in whatever format, all-lowercase, all-uppercase, camelCase, capilized. It is mapped correctly in the app. Similarly, all type of messages are mapped in all-lowercase in response.

- Depending on the request we send to subscribe to a product in ws feed, now we get validation. 

If it is a success we can get
```json
{
    "type": "subscriptions",
    "message": "Successfully subscribed to coinbase websocket feed",
    "productIds": [
        "BTC-EUR"
    ]
}
```
If it is an error we can get
```json
{
  "type":"error",
  "message":"Failed to subscribe",
  "reason":"BdC-EUR is not a valid product"
}
```

On error, the ws client closes.