### PR TITLE
Fix analyzer subscription request

### DIFF
--- a/crypto-analyzer/src/main.py
+++ b/crypto-analyzer/src/main.py
@@ -1,5 +1,6 @@
 import time
-from utils.adapter_request_helper import subscribe_products, cb_auth_request
+import sys
+from utils.adapter_request_helper import subscribe_products, cb_auth_request, get_active_subs
 from utils.db_connection import connect_to_db, print_feed
 from utils.config_handling import ConfigHandler
 from data.query_functions import get_latest_prices
@@ -13,10 +14,17 @@ def main():
     print("Reading config file...")
     handler = ConfigHandler()
 
-    print("Sleeping...")
-    time.sleep(5)
     cb_auth_request(handler)
-    subscribe_products(handler, "BTC-EUR")
+
+    print("Subscribing...")
+    active_subs = list(get_active_subs(handler))
+    print(type(active_subs), active_subs)
+    if not active_subs:
+        subscribe_products(handler, "BTC-EUR")
+    else:
+        print("Already subscribed")
+
+    sys.stdout.flush()
 
     connect_to_db(handler)
     print_feed()

--- a/crypto-analyzer/src/main.py
+++ b/crypto-analyzer/src/main.py
@@ -13,15 +13,15 @@ def main():
     print("Reading config file...")
     handler = ConfigHandler()
 
-    print("Sleeping for ten seconds...")
+    print("Sleeping...")
     time.sleep(5)
     cb_auth_request(handler)
     subscribe_products(handler, "BTC-EUR")
 
     connect_to_db(handler)
-    # print_feed()
-    values = get_latest_prices(20)
-    print(values)
+    print_feed()
+    # values = get_latest_prices(20)
+    # print(values)
 
 
 if __name__ == "__main__":

--- a/crypto-analyzer/src/resources/analyzer_configuration.yml
+++ b/crypto-analyzer/src/resources/analyzer_configuration.yml
@@ -1,6 +1,7 @@
 coinbase_adapter:
     subscribe: /api/coinbase/wsFeed/subscribe
     auth: /api/auth
+    subscriptions: /api/subscriptions
     host: localhost
     port: 9000
     subscribe_body:

--- a/crypto-analyzer/src/resources/analyzer_configuration.yml
+++ b/crypto-analyzer/src/resources/analyzer_configuration.yml
@@ -1,5 +1,5 @@
 coinbase_adapter:
-    subscribe: /api/coinbase/subscribe
+    subscribe: /api/coinbase/wsFeed/subscribe
     auth: /api/auth
     host: localhost
     port: 9000

--- a/crypto-analyzer/src/utils/adapter_request_helper.py
+++ b/crypto-analyzer/src/utils/adapter_request_helper.py
@@ -30,3 +30,10 @@ def subscribe_products(config_handler, *args):
 
     r = requests.post(subscribe_endpoint, json=body, headers=headers)
     print(r.text)
+
+def get_active_subs(config_handler):
+    headers = {"Authorization": "Basic {}".format(
+        config_handler.auth_token)}
+    subscriptions_endpoint = config_handler.subscriptions
+    r = requests.get(subscriptions_endpoint, headers=headers)
+    return r.json()

--- a/crypto-analyzer/src/utils/config_handling.py
+++ b/crypto-analyzer/src/utils/config_handling.py
@@ -66,3 +66,9 @@ class ConfigHandler:
     @property
     def password(self):
         return os.environ['COINBASE_ADAPTER_BASIC_AUTH_PWD']
+
+    @property
+    def subscriptions(self):
+        return self.__construct_url(
+            self.config_data['coinbase_adapter']['subscriptions']
+        )


### PR DESCRIPTION
# Main points of implementation

- Fixes the request for new subscriptions by incorporating the update endpoint (just a configuration change)
- Implements the use of the new active subscriptions endpoint in order to avoid duplicate subscriptions

## Testing

In order to test the implementation just run the usual `docker-compose up -d --build` and check the logs of crypto analyzer with `docker logs -f crypto_analyzer`. The intended behavior is to subscribe to one product and start showing fetched information. After that you can try to restart the analyzer with `docker-compose restart crypto-analyzer-service` and it should say that there are already active subscriptions.