### PR TITLE
Change crypro analyzer container set up

### DIFF
--- a/crypto-analyzer/Dockerfile
+++ b/crypto-analyzer/Dockerfile
@@ -1,4 +1,4 @@
-FROM quoinedev/python3.6-pandas-alpine
+FROM python:3.8-slim
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 COPY src/ myapp/

--- a/crypto-analyzer/Dockerfile
+++ b/crypto-analyzer/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.8-slim
-COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
-COPY src/ myapp/
-WORKDIR /myapp/
+RUN pip install pipenv
+ENV PROJECT_DIR /usr/local/src/myapp
+WORKDIR ${PROJECT_DIR}
+COPY Pipfile Pipfile.lock ${PROJECT_DIR}/
+RUN pipenv install --system --deploy
+COPY src/ ${PROJECT_DIR}/
 ENTRYPOINT ["python", "./main.py"]

--- a/crypto-analyzer/requirements.txt
+++ b/crypto-analyzer/requirements.txt
@@ -1,9 +1,0 @@
--i https://pypi.org/simple
-certifi==2020.4.5.1
-chardet==3.0.4
-idna==2.9
-pyyaml==5.3.1
-requests==2.23.0
-rethinkdb==2.4.6
-six==1.14.0
-urllib3==1.25.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     build: ./crypto-analyzer
     depends_on:
       - realtime-db
+      - coinbase-adapter-service
     container_name: crypto_analyzer
 #    restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - realtime-db
       - coinbase-adapter-service
     container_name: crypto_analyzer
-#    restart: always
+    restart: always
     environment:
       RETHINK_DB_HOST: ${RETHINK_DB_HOST}
       COINBASE_ADAPTER_BASIC_AUTH_USER: ${COINBASE_ADAPTER_BASIC_AUTH_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     depends_on:
       - realtime-db
     container_name: crypto_analyzer
-    restart: always
+#    restart: always
     environment:
       RETHINK_DB_HOST: ${RETHINK_DB_HOST}
       COINBASE_ADAPTER_BASIC_AUTH_USER: ${COINBASE_ADAPTER_BASIC_AUTH_USER}


### PR DESCRIPTION
Ok so based on some research here are the new changes:

- Changed the base image for the python staff (see [this](https://pythonspeed.com/articles/alpine-docker-python/))
- New base image is python 3.8 slim based on [this](https://pythonspeed.com/articles/base-image-python-docker-images/)
- New package management system for python Pipenv (you can find more about it [here](https://pypi.org/project/pipenv/) and why we should use it [here](https://realpython.com/pipenv-guide/#problems-that-pipenv-solves) and [here](https://medium.com/better-programming/improve-your-python-package-management-with-pipenv-28093c007955))

That's all folks. Of course you should test everything works fine! Just run the following commands from the root of the project.

`docker-compose up -d --build`
`docker-compose logs -f crypto-analyzer-service`

The intended output must be something like this:
```
crypto_analyzer             | ==================================
crypto_analyzer             | HELLO!! -- CRYPTO-ANALYZER SERVICE
crypto_analyzer             | ==================================
crypto_analyzer             | Reading config file...
crypto_analyzer             | Subscribing...
crypto_analyzer             | <class 'list'> []
crypto_analyzer             | {"type":"subscriptions","message":"Successfully subscribed to coinbase websocket feed","productIds":["BTC-EUR"]}
crypto_analyzer             | {'best_ask': '9084.95', 'best_bid': '9084.94', 'high_24h': '9720', 'id': 'f731d2f2-3ad4-4810-ab05-ad569476326c', 'last_size': '0.01862025', 'low_24h': '8901', 'open_24h': '9626.29', 'price': '9084.95', 'product_id': 'BTC-EUR', 'sequence': '8315078736', 'side': 'BUY', 'time': datetime.datetime(2020, 9, 3, 21, 47, 31, 440000, tzinfo=<rethinkdb.ast.RqlTzinfo object at 0x7fbea881de50>), 'trade_id': '29276708', 'type': 'TICKER', 'volume_24h': '3867.17456404', 'volume_30d': '49131.30159772'}
crypto_analyzer             | {'best_ask': '9084.94', 'best_bid': '9084.93', 'high_24h': '9720', 'id': '3a97a8ad-e861-4026-bb5f-1f49b256a4ff', 'last_size': '0.061', 'low_24h': '8901', 'open_24h': '9626.29', 'price': '9084.94', 'product_id': 'BTC-EUR', 'sequence': '8315079003', 'side': 'BUY', 'time': datetime.datetime(2020, 9, 3, 21, 47, 35, 504000, tzinfo=<rethinkdb.ast.RqlTzinfo object at 0x7fbea881de20>), 'trade_id': '29276709', 'type': 'TICKER', 'volume_24h': '3867.23556404', 'volume_30d': '49131.36259772'}
crypto_analyzer             | {'best_ask': '9084.94', 'best_bid': '9084.93', 'high_24h': '9720', 'id': '0cd02097-44c6-46f6-bbef-d911937df75c', 'last_size': '0.02106483', 'low_24h': '8901', 'open_24h': '9626.29', 'price': '9084.94', 'product_id': 'BTC-EUR', 'sequence': '8315079033', 'side': 'BUY', 'time': datetime.datetime(2020, 9, 3, 21, 47, 36, 80000, tzinfo=<rethinkdb.ast.RqlTzinfo object at 0x7fbea881dd00>), 'trade_id': '29276710', 'type': 'TICKER', 'volume_24h': '3867.25662887', 'volume_30d': '49131.38366255'}
crypto_analyzer             | {'best_ask': '9084.94', 'best_bid': '9084.93', 'high_24h': '9720', 'id': '3fc7d491-d6d3-4042-bd7a-7c8f1b3fa4e7', 'last_size': '0.03129904', 'low_24h': '8901', 'open_24h': '9626.29', 'price': '9084.94', 'product_id': 'BTC-EUR', 'sequence': '8315079512', 'side': 'BUY', 'time': datetime.datetime(2020, 9, 3, 21, 47, 41, 949000, tzinfo=<rethinkdb.ast.RqlTzinfo object at 0x7fbea881deb0>), 'trade_id': '29276712', 'type': 'TICKER', 'volume_24h': '3867.33132741', 'volume_30d': '49131.45836109'}
crypto_analyzer             | {'best_ask': '9084.94', 'best_bid': '9084.93', 'high_24h': '9720', 'id': 'bb340518-5d0f-458b-921b-184b57df68f9', 'last_size': '0.0433995', 'low_24h': '8901', 'open_24h': '9626.29', 'price': '9084.94', 'product_id': 'BTC-EUR', 'sequence': '8315079407', 'side': 'BUY', 'time': datetime.datetime(2020, 9, 3, 21, 47, 40, 668000, tzinfo=<rethinkdb.ast.RqlTzinfo object at 0x7fbea881dbe0>), 'trade_id': '29276711', 'type': 'TICKER', 'volume_24h': '3867.30002837', 'volume_30d': '49131.42706205'}
```