### PR TITLE
implements db migrations

### DIFF
--- a/db-initializer/Dockerfile
+++ b/db-initializer/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:slim
+RUN pip install rethinkdb
+WORKDIR /usr/local/src
+COPY init_db.py .
+# CMD ["tail", "-f", "/dev/null"]
+CMD [ "python", "init_db.py" ]

--- a/db-initializer/init_db.py
+++ b/db-initializer/init_db.py
@@ -1,0 +1,19 @@
+import os
+from rethinkdb import RethinkDB
+
+
+rethink_host = os.environ['RETHINK_HOST']
+
+r = RethinkDB()
+r.connect(rethink_host, 28015).repl()
+
+r.db_drop('test').run()
+r.db_create('cryptobot').run()
+
+r.db('cryptobot').table_create('messages').run()
+r.db('cryptobot').table_create('product_subscriptions').run()
+
+r.db('cryptobot').table('product_subscriptions').insert({
+    'sub_id': 'coinbase-pro-subscription',
+    'product_ids': ''
+}).run()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,13 @@ services:
     ports:
     - 8000:8080
     - 28015:28015
+  db-initializer:
+    build: ./db-initializer
+    depends_on:
+      - realtime-db
+    environment:
+      RETHINK_HOST: ${RETHINK_DB_HOST}
+    container_name: db-initializer
   graphql:
     build: ./graphql
     depends_on:


### PR DESCRIPTION
Creates a new service `db-initializer` which makes the following initialization:

- Deletes the `test` database which is created by default when spinning `rethinkdb`
- Creates the `cryptobot` database
- In that database, creates the tables `messages` and `product_subscriptions`
- In the `product_subscriptions` table inserts a specific row.