### PR TITLE
Analyzer workflow fix

### DIFF
--- a/.github/workflows/crypto-analyzer-publish.yml
+++ b/.github/workflows/crypto-analyzer-publish.yml
@@ -15,27 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-      # install prerequisites for installing packages and testing
-      - name: Install prerequisites
-        run: python -m pip install --upgrade pipenv flake8 wheel
-      # Caching dependencies
-      - name: Cache Pipenv dependencies
-        uses: actions/cache@v2
-        with:
-          # This path is specific to Ubuntu
-          path: ~/.local/share/virtualenvs
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pipenv-
-      - name: Install dependencies
-        run: |
-          cd crypto-analyzer/
-          pipenv install --system --deploy
       - name: Publish docker image to ghcr
         working-directory: ./ci-scripts
         run: bash build_image_and_publish.sh crypto-analyzer ${{ secrets.PAT_GHCR }}

--- a/crypto-analyzer/src/cryptobot_api.py
+++ b/crypto-analyzer/src/cryptobot_api.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     # print(subscriptions)
 
     # create product to subscribe
-    btc_eur_product = Product("ETH-USD")
+    btc_eur_product = Product("LTC-USD")
 
     if btc_eur_product.title not in subscriptions:
         # subscibe


### PR DESCRIPTION
Removed the redundant staff on the publish workflow for `crypto-analyzer`.

- Before:
    - it was installing libraries both in docker container and on github's workflow host machine
- After:
    - it installs libraries only in docker cointainer